### PR TITLE
Added ability to specify column labels.

### DIFF
--- a/spec/GoogleVisualization/DataSourceGeneratorSpec.php
+++ b/spec/GoogleVisualization/DataSourceGeneratorSpec.php
@@ -57,8 +57,9 @@ class DataSourceGeneratorSpec extends ObjectBehavior
 
     function it_creates_valid_cells_from_a_single_object()
     {
-        $inputData = json_decode('[{"gender":"male", "age":27},{"gender":"female", "age":24}]');
-        $outputData = $this->createCells($inputData[0], ["gender" => "string"]);
+        $columns    = json_decode('[{"id": "gender", "type": "string"}]');
+        $inputData  = json_decode('[{"gender":"male", "age":27},{"gender":"female", "age":24}]');
+        $outputData = $this->createCells($inputData[0], $columns);
         $outputData->shouldBeArray();
         $outputData->shouldHaveCount(1);
         $outputData[0]->v->shouldBeLike('male');
@@ -66,8 +67,9 @@ class DataSourceGeneratorSpec extends ObjectBehavior
 
     function it_creates_multiple_valid_cells_from_a_single_object()
     {
-        $inputData = json_decode('[{"gender":"male", "age":27},{"gender":"female", "age":24}]');
-        $outputData = $this->createCells($inputData[0], ["gender" => "string", "age" => "number"]);
+        $columns    = json_decode('[{"id": "gender", "type": "string"}, {"id": "age", "type": "number"}]');
+        $inputData  = json_decode('[{"gender":"male", "age":27},{"gender":"female", "age":24}]');
+        $outputData = $this->createCells($inputData[0], $columns);
         $outputData->shouldBeArray();
         $outputData->shouldHaveCount(2);
         $outputData[0]->v->shouldBeLike('male');

--- a/src/GoogleVisualization/DataSourceGenerator.php
+++ b/src/GoogleVisualization/DataSourceGenerator.php
@@ -44,13 +44,18 @@ class DataSourceGenerator
 
         $ds = new DataSource();
         // Create columns
-        foreach ($columns as $id => $type) {
-            $ds->cols[] = static::createColumn(['type' => $type, 'id' => $id]);
+        foreach ($columns as $id => $column) {
+            if (is_array($column)) {
+                $column['id'] = $id;
+                $ds->cols[]   = static::createColumn($column);
+            } else {
+                $ds->cols[] = static::createColumn(['type' => $column, 'id' => $id]);
+            }
         }
         // Create rows
         foreach ($objects as $object) {
             $row = new \stdClass();
-            $row->c = static::createCells($object, $columns);
+            $row->c = static::createCells($object, $ds->cols);
             $ds->rows[] = $row;
         }
 
@@ -91,26 +96,26 @@ class DataSourceGenerator
         // Iterate over columns array for correct order
         // Use key to extract value from object and create new cell
         $objectArr = (array)$object;
-        foreach ($columns as $key => $type) {
+        foreach ($columns as $column) {
             $cell = new \stdClass();
-            switch ($type) {
+            switch ($column->type) {
                 case 'number':
-                    if (is_numeric($objectArr[$key]) || is_null($objectArr[$key])) {
-                        $cell->v = $objectArr[$key] + 0;
+                    if (is_numeric($objectArr[$column->id]) || is_null($objectArr[$column->id])) {
+                        $cell->v = $objectArr[$column->id] + 0;
                     } else {
                         throw new \InvalidArgumentException("A field that was supposed to be interpreted as a number is not numeric");
                     }
                     break;
                 case 'datetime':
                 case 'date':
-                    if (is_null($objectArr[$key]) || strcasecmp($objectArr[$key], "null") === 0) {
+                    if (is_null($objectArr[$column->id]) || strcasecmp($objectArr[$column->id], "null") === 0) {
                         $cell->v = null;
                     } else {
-                        $cell->v = new \DateTime($objectArr[$key]);
+                        $cell->v = new \DateTime($objectArr[$column->id]);
                     }
                     break;
                 default:
-                    $cell->v = $objectArr[$key];
+                    $cell->v = $objectArr[$column->id];
                     break;
             }
             $cells[] = $cell;


### PR DESCRIPTION
Added the ability to add labels to columns.

The format for adding labels, or any other column attribute, is shown below.

``` php
$columns = [
    'date'  => [
        'type'  => 'date',
        'label' => 'Date',
    ],
    'total' => [
        'type'  => 'number',
        'label' => 'Total',
    ],
];
```

Backwards compatibility with the simpler current format is kept, so no breaking change.

``` php
$columns = [
    'date' => 'date',
    'total' => 'number',
];
```

To make this effect the DataSource columns value is passed to createCells() instead of the user generated value as it has already be converted to a common predicable format. The spec tests have been change to show this and tests are passing 100%.
